### PR TITLE
Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/factchecking-benchmark/dependency-reduced-pom.xml
+++ b/factchecking-benchmark/dependency-reduced-pom.xml
@@ -52,12 +52,12 @@
     <repository>
       <id>maven.aksw.internal</id>
       <name>University Leipzig, AKSW Maven2 Repository</name>
-      <url>http://maven.aksw.org/repository/internal</url>
+      <url>https://maven.aksw.org/repository/internal</url>
     </repository>
     <repository>
       <id>maven.aksw.snapshots</id>
       <name>University Leipzig, AKSW Maven2 Repository</name>
-      <url>http://maven.aksw.org/repository/snapshots</url>
+      <url>https://maven.aksw.org/repository/snapshots</url>
     </repository>
   </repositories>
 </project>

--- a/factchecking-benchmark/pom.xml
+++ b/factchecking-benchmark/pom.xml
@@ -14,12 +14,12 @@
 		<repository>
 			<id>maven.aksw.internal</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/repository/internal</url>
+			<url>https://maven.aksw.org/repository/internal</url>
 		</repository>
 		<repository>
 			<id>maven.aksw.snapshots</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/repository/snapshots</url>
+			<url>https://maven.aksw.org/repository/snapshots</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Resolve dependencies of the AKSW repository over https.